### PR TITLE
Only show Link Types if they exist on the Link Graph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
 - Increase the zoom out limit for the toctree graph 
 - Add stats for images
 - Remove images from Includes graph and stats
+- Only show Link Types if they exist on the Link Graph
 
 0.8.1
 -----

--- a/sphinx_visualized/static/js/link-graph.js
+++ b/sphinx_visualized/static/js/link-graph.js
@@ -680,8 +680,15 @@ window.addEventListener('DOMContentLoaded', async () => {
         });
       });
 
-      const renderLinkTypesPanel = async () => {
-        const linkTypes = Object.keys(LINK_TYPE_CONFIG);
+      // Filter to only link types that actually exist in the graph
+      const existingLinkTypes = Object.keys(LINK_TYPE_CONFIG).filter(type => edgesPerLinkType[type] > 0);
+
+      // Only render the panel if there are link types with edges
+      if (existingLinkTypes.length === 0) {
+        linkTypesContainer.style.display = 'none';
+      } else {
+        const renderLinkTypesPanel = async () => {
+          const linkTypes = existingLinkTypes;
         const visibleCount = linkTypes.filter(t => visibleLinkTypes[t]).length;
 
         // Calculate max edges for progress bar scaling
@@ -806,7 +813,8 @@ window.addEventListener('DOMContentLoaded', async () => {
         });
       };
 
-      renderLinkTypesPanel();
+        renderLinkTypesPanel();
+      }
     }
 
     // Search functionality


### PR DESCRIPTION
## Summary of changes

- Only show Link Types if they exist on the Link Graph

docs: https://sphinx-visualized--46.org.readthedocs.build/en/46/_static/sphinx-visualized/html/link-graph.html

Fixes: https://github.com/jdillard/sphinx-visualized/issues/39